### PR TITLE
Convert timestamps between ROS and CPP

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,4 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - uses: pre-commit/action@v3.0.0

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 [Kinematic-ICP](https://www.ipb.uni-bonn.de/wp-content/papercite-data/pdf/kissteam2025icra.pdf) is a LiDAR odometry approach that explicitly incorporates the kinematic constraints of mobile robots into the classic point-to-point ICP algorithm.
 
-<img src="https://github.com/user-attachments/assets/93826e4b-7319-459b-9d84-83929606ef4d" alt="Kinematic-ICP" width="500"/>
+<img src="https://github.com/user-attachments/assets/c12195e0-4ca0-415e-814f-783ca77423d9" alt="Kinematic-ICP" width="500"/>
 
 </div>
 

--- a/ros/include/kinematic_icp_ros/server/LidarOdometryServer.hpp
+++ b/ros/include/kinematic_icp_ros/server/LidarOdometryServer.hpp
@@ -68,7 +68,7 @@ private:
                        const std::vector<Eigen::Vector3d> keypoints);
 
     // Temporal initializaiton strattegy until we convert the odometry server to life cycle
-    void InitializePoseAndExtrinsic(const std::string &lidar_frame_id);
+    void InitializePoseAndExtrinsic(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg);
 
     /// Tools for broadcasting TFs.
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
@@ -99,7 +99,7 @@ private:
     std::string wheel_odom_frame_{"odom"};
     std::string base_frame_{"base_link"};
     // TF frame initialization flag
-    bool initialize_odom_node;
+    bool initialize_odom_node{false};
 
     rclcpp::Node::SharedPtr node_;
 };

--- a/ros/src/kinematic_icp_ros/server/LidarOdometryServer.cpp
+++ b/ros/src/kinematic_icp_ros/server/LidarOdometryServer.cpp
@@ -64,7 +64,7 @@ auto TimeToROSStamp(const double &time) {
 };
 double ROSStampToTime(const builtin_interfaces::msg::Time stamp) {
     double time = static_cast<double>(stamp.sec);
-    time += static_cast<double>(stamp.nanosec) * 1e9;
+    time += static_cast<double>(stamp.nanosec) * 1e-9;
     return time;
 };
 }  // namespace


### PR DESCRIPTION
This PR fixes some timestamp conversions between ROS and C++. This mainly concerns the velocity computation used to estimate the twist for the `OdometryMsg.` I decided to put these conversions in an unnamed namespace, as (I hope) they will be used only in the `LidarOdometryServer.` 