### PR TITLE
Pin down to 3.10

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,4 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
There is an issue with installing pre-commit on Python 11, therefore we have to pin it down to 3.10 for the CI

see https://github.com/pre-commit/pre-commit/issues/2922