### PR TITLE
Consistency in CMakeLists.txt

### DIFF
--- a/cpp/kinematic_icp/CMakeLists.txt
+++ b/cpp/kinematic_icp/CMakeLists.txt
@@ -26,7 +26,7 @@ project(kinematic_icp_cpp VERSION 0.0.1 LANGUAGES CXX)
 # Setup build options for the underlying kiss dependency
 option(USE_CCACHE "Build using Ccache if found on the path" ON)
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)
-option(USE_SYSTEM_SOPHUS "Use system pre-installed Sophus" OFF)
+option(USE_SYSTEM_SOPHUS "Use system pre-installed Sophus" ON)
 option(USE_SYSTEM_TSL-ROBIN-MAP "Use system pre-installed tsl_robin" ON)
 option(USE_SYSTEM_TBB "Use system pre-installed oneAPI/tbb" ON)
 include(kiss_icp/kiss-icp.cmake)


### PR DESCRIPTION
Make *USE_SYSTEM_SOPHUS* consistent with the rest of the options.