### PR TITLE
Fixing ROS launch system

### DIFF
--- a/ros/launch/common_args.launch.py
+++ b/ros/launch/common_args.launch.py
@@ -43,14 +43,9 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "visualize",
-                default_value="true",
+                default_value="false",
                 description="",
                 choices=["true", "false"],
-            ),
-            DeclareLaunchArgument(
-                "bag_filenames",
-                default_value="",
-                description="Comma-separated list of file paths",
             ),
         ]
     )

--- a/ros/launch/online_node.launch.py
+++ b/ros/launch/online_node.launch.py
@@ -2,10 +2,10 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import (
     get_launch_description_from_python_launch_file,
 )
-from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 from launch_ros.substitutions.find_package import get_package_share_directory


### PR DESCRIPTION
There were some last-minute changes in the launch system used in the project before the open-source release. In the process the rviz node got removed from the `online_node` launch, and we didn't realize it because we assumed the default value of the `visualize` flag was set to `false`, while it was `true`. This PR fixes both issues:

1. Re-introduce the Rviz node into the `online_node` launch.
2. Set the `visualize` flag to false by default
3. Remove legacy (project is open-source from 5 minutes but ok) parameter `bag_filenames`