### PR TITLE
Fix for at least two types of timestamps in PointCloud2 messages

### DIFF
--- a/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
+++ b/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
@@ -58,8 +58,8 @@ std::vector<double> NormalizeTimestamps(const std::vector<double> &timestamps) {
 auto ExtractTimestampsFromMsg(const PointCloud2::ConstSharedPtr msg,
                               const PointField &timestamp_field) {
     auto number_of_digits_decimal_part = [](const auto &stamp) {
-        const uint64_t converted_stamp = static_cast<uint64_t>(std::round(stamp));
-        return converted_stamp > 0 ? std::floor(std::log10(converted_stamp) + 1) : 1;
+        const uint64_t number_of_seconds = static_cast<uint64_t>(std::round(stamp));
+        return number_of_seconds > 0 ? std::floor(std::log10(number_of_seconds) + 1) : 1;
     };
     auto extract_timestamps =
         [&]<typename T>(sensor_msgs::PointCloud2ConstIterator<T> &&it) -> std::vector<double> {

--- a/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
+++ b/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
@@ -68,9 +68,10 @@ auto ExtractTimestampsFromMsg(const PointCloud2::ConstSharedPtr msg,
         timestamps.reserve(n_points);
         for (size_t i = 0; i < n_points; ++i, ++it) {
             double stampd = static_cast<double>(*it);
-            // If the number of digits is greater than 10,
-            // the stamp is in nanoseconds instead of seconds, perform conversion
-            if (number_of_digits_decimal_part(*it) > 10) {
+            // If the number of digits is greater than 10 (which is the maximum number of digits
+            // that can be represented with a 32 bits integer), the stamp is in nanoseconds instead
+            // of seconds, perform conversion
+            if (number_of_digits_decimal_part(stampd) > 10) {
                 stampd *= 1e-9;
             }
             timestamps.emplace_back(stampd);

--- a/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
+++ b/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
@@ -22,6 +22,9 @@
 // SOFTWARE.
 #include "kinematic_icp_ros/utils/RosUtils.hpp"
 
+#include <cmath>
+#include <cstdint>
+
 namespace kinematic_icp_ros::utils {
 
 std::optional<PointField> GetTimestampField(const PointCloud2::ConstSharedPtr msg) {
@@ -54,13 +57,23 @@ std::vector<double> NormalizeTimestamps(const std::vector<double> &timestamps) {
 
 auto ExtractTimestampsFromMsg(const PointCloud2::ConstSharedPtr msg,
                               const PointField &timestamp_field) {
+    auto number_of_digits_decimal_part = [](const auto &stamp) {
+        const uint64_t converted_stamp = static_cast<uint64_t>(std::round(stamp));
+        return converted_stamp > 0 ? std::floor(std::log10(converted_stamp) + 1) : 1;
+    };
     auto extract_timestamps =
-        [&msg]<typename T>(sensor_msgs::PointCloud2ConstIterator<T> &&it) -> std::vector<double> {
+        [&]<typename T>(sensor_msgs::PointCloud2ConstIterator<T> &&it) -> std::vector<double> {
         const size_t n_points = msg->height * msg->width;
         std::vector<double> timestamps;
         timestamps.reserve(n_points);
         for (size_t i = 0; i < n_points; ++i, ++it) {
-            timestamps.emplace_back(static_cast<double>(*it));
+            double stampd = static_cast<double>(*it);
+            // If the number of digits is greater than 10,
+            // the stamp is in nanoseconds instead of seconds, perform conversion
+            if (number_of_digits_decimal_part(*it) > 10) {
+                stampd *= 1e-9;
+            }
+            timestamps.emplace_back(stampd);
         }
         return timestamps;
     };

--- a/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
+++ b/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
@@ -22,8 +22,7 @@
 // SOFTWARE.
 #include "kinematic_icp_ros/utils/RosUtils.hpp"
 
-#include <cmath>
-#include <cstdint>
+#include <limits>
 
 namespace kinematic_icp_ros::utils {
 
@@ -57,23 +56,19 @@ std::vector<double> NormalizeTimestamps(const std::vector<double> &timestamps) {
 
 auto ExtractTimestampsFromMsg(const PointCloud2::ConstSharedPtr msg,
                               const PointField &timestamp_field) {
-    auto number_of_digits_decimal_part = [](const auto &stamp) {
-        const uint64_t number_of_seconds = static_cast<uint64_t>(std::round(stamp));
-        return number_of_seconds > 0 ? std::floor(std::log10(number_of_seconds) + 1) : 1;
-    };
     auto extract_timestamps =
-        [&]<typename T>(sensor_msgs::PointCloud2ConstIterator<T> &&it) -> std::vector<double> {
+        [&msg]<typename T>(sensor_msgs::PointCloud2ConstIterator<T> &&it) -> std::vector<double> {
         const size_t n_points = msg->height * msg->width;
         std::vector<double> timestamps;
         timestamps.reserve(n_points);
         for (size_t i = 0; i < n_points; ++i, ++it) {
-            double stampd = static_cast<double>(*it);
-            // If the number of digits is greater than 10,
+            double stamp = static_cast<double>(*it);
+            // If the stamp is larger than int32,
             // the stamp is in nanoseconds instead of seconds, perform conversion
-            if (number_of_digits_decimal_part(*it) > 10) {
-                stampd *= 1e-9;
+            if (*it > std::numeric_limits<int32_t>::max()) {
+                stamp *= 1e-9;
             }
-            timestamps.emplace_back(stampd);
+            timestamps.emplace_back(stamp);
         }
         return timestamps;
     };

--- a/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
+++ b/ros/src/kinematic_icp_ros/utils/RosUtils.cpp
@@ -63,8 +63,8 @@ auto ExtractTimestampsFromMsg(const PointCloud2::ConstSharedPtr msg,
         timestamps.reserve(n_points);
         for (size_t i = 0; i < n_points; ++i, ++it) {
             double stamp = static_cast<double>(*it);
-            // If the stamp is larger than int32,
-            // the stamp is in nanoseconds instead of seconds, perform conversion
+            // If the stamp is larger than the max of int32, we assume the stamp is in
+            // nanoseconds instead of seconds and perform conversion
             if (*it > std::numeric_limits<int32_t>::max()) {
                 stamp *= 1e-9;
             }


### PR DESCRIPTION
This is mainly to tackle the issue reported in #12 . In essence, some drivers (in this case the Livox driver) express the timestamps in nanoseconds, while other vendors (e.g. Ouster if my mind doesn't fail me) report the stamp directly in seconds. To handle the scenario I decided to count the digits of the timestamps, as we know that ROS stores the seconds and nanoseconds in `int32`. As this type cannot handle more than 10 digits, any stamp with more than 10 digits in the integer part of the floating point is assumed to be expressed in nanoseconds and converted. 

It will need some testing to be sure but on the preliminary analysis, I don't see any difference in results for our data. @KenN7 can you test it on your stuff? or if you can send me the data ;)