### PR TITLE
Revise timestamping

### DIFF
--- a/ros/src/kinematic_icp_ros/server/LidarOdometryServer.cpp
+++ b/ros/src/kinematic_icp_ros/server/LidarOdometryServer.cpp
@@ -188,10 +188,13 @@ void LidarOdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::Con
     auto toStamp = [](const double &time) -> builtin_interfaces::msg::Time {
         return rclcpp::Time(tf2::durationFromSec(time).count());
     };
-    // Update what is the current stamp of this iteration
-    const auto begin_scan_stamp = min_it != timestamps.cend() ? toStamp(*min_it) : last_stamp;
-    const auto end_scan_stamp = max_it != timestamps.cend() ? toStamp(*max_it) : msg->header.stamp;
-    current_stamp_ = end_scan_stamp;
+
+    // Get scan duration and current stamp
+    const auto begin_scan_time = min_it != timestamps.cend() ? *min_it : toTime(last_stamp);
+    const auto end_scan_time = max_it != timestamps.cend() ? *max_it : toTime(msg->header.stamp);
+    const double scan_duration = end_scan_stamp - begin_scan_stamp;
+    current_stamp_ = begin_scan_time < toTime(last_stamp) ? toStamp(last_stamp_) + scan_duration
+                                                          : toStamp(end_scan_stamp);
 
     // Get the initial guess from the wheel odometry
     const auto delta = LookupDeltaTransform(base_frame_, last_stamp_, base_frame_, current_stamp_,

--- a/ros/src/kinematic_icp_ros/server/LidarOdometryServer.cpp
+++ b/ros/src/kinematic_icp_ros/server/LidarOdometryServer.cpp
@@ -192,10 +192,10 @@ void LidarOdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::Con
     const auto begin_scan_stamp = min_it != timestamps.cend() ? toStamp(*min_it) : last_stamp;
     const auto end_scan_stamp = max_it != timestamps.cend() ? toStamp(*max_it) : msg->header.stamp;
     current_stamp_ = end_scan_stamp;
+
     // Get the initial guess from the wheel odometry
-    const auto delta =
-        LookupDeltaTransform(base_frame_, last_stamp_, base_frame_, end_scan_stamp,
-                             wheel_odom_frame_, tf_timeout_, tf2_buffer_);
+    const auto delta = LookupDeltaTransform(base_frame_, last_stamp_, base_frame_, current_stamp_,
+                                            wheel_odom_frame_, tf_timeout_, tf2_buffer_);
 
     // Run kinematic ICP
     if (delta.log().norm() > 1e-3) {

--- a/ros/src/kinematic_icp_ros/server/LidarOdometryServer.cpp
+++ b/ros/src/kinematic_icp_ros/server/LidarOdometryServer.cpp
@@ -194,7 +194,7 @@ void LidarOdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::Con
     current_stamp_ = end_scan_stamp;
     // Get the initial guess from the wheel odometry
     const auto delta =
-        LookupDeltaTransform(base_frame_, begin_scan_stamp, base_frame_, end_scan_stamp,
+        LookupDeltaTransform(base_frame_, last_stamp_, base_frame_, end_scan_stamp,
                              wheel_odom_frame_, tf_timeout_, tf2_buffer_);
 
     // Run kinematic ICP


### PR DESCRIPTION
There are some inconsistencies in our timestamping that this PR addresses to fix.

First, we currently query the TF tree for the odometry from the beginning to the end of the current scan. This is incorrect because the sensor might drop frames, and we, in that case, ignore the odometry during that time.

Second, we assume that the timestamps of the points are absolute, which is not necessarily the case.

We can still not cover one case: if the timestamp of the ROS message is the beginning of the scan and no timestamps are provided for the points. In such a case, there is no way to query the correct odometry from TF because the exact timestamp at the scan's end is unknown.