### PR TITLE
Bump version

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.apt/cache
           key: ${{ runner.os }}-apt-${{ hashFiles('**/ubuntu_dependencies.yml') }}


### PR DESCRIPTION
Fixes https://github.com/PRBonn/kinematic-icp/actions/runs/16171174698/job/45983273673?pr=37#step:1:40

```shell
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```